### PR TITLE
Update 108.Entrypoint_argumentos_variables_entorno.md

### DIFF
--- a/docs/cursos/docker/108.Entrypoint_argumentos_variables_entorno.md
+++ b/docs/cursos/docker/108.Entrypoint_argumentos_variables_entorno.md
@@ -44,11 +44,15 @@ Para pasar argumentos a nuestro proceso de construcción, podemos utilizar la in
 ```Dockerfile
 FROM alpine
 
+# Declarar un argumento con un valor predeterminado
 ARG NOMBRE="Mundo"
 
-RUN echo "Hola $NOMBRE" > message 
+# Crear un archivo que contenga el mensaje personalizado
+RUN echo "Hola $NOMBRE" > /message 
 
-CMD ["echo", "message"]
+# Comando predeterminado para mostrar el contenido del archivo
+CMD ["cat", "/message"]
+
 ```
 
 En este caso, estamos definiendo un argumento `NOMBRE` con el valor por defecto `Mundo`. Si construimos la imagen con el comando `docker build -t saludador .`, al iniciar un contenedor con el comando `docker run saludador`, se ejecutará el comando `echo Hola Mundo`.


### PR DESCRIPTION
Traté de replicar el ejemplo con múltiples combinaciones y no lograba que funcionara, en tiempo de compilación no se crea la variable, consultando con ChatGPT(soy novato), sugiere exportar la salida a un archivo en la raíz del contenedor y al ejecutarlo tomaría el valor del archivo, así si me funcionó aprovecho para darte gracias por el curso, es muy bueno, Saludos Mauricio desde Colombia.