### PR TITLE
Actualización instrucciones de instalación de Helm y reemplazo de comandos apt-get por apt

### DIFF
--- a/docs/cursos/kubernetes/103.Instalacion.md
+++ b/docs/cursos/kubernetes/103.Instalacion.md
@@ -84,7 +84,7 @@ $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev
 
 6. Instalar containerd y configurar el daemon para que use cgroups de systemd:
 ```bash
-apt-get update && apt-get install containerd.io -y
+apt update && apt install containerd.io -y
 
 containerd config default | tee /etc/containerd/config.toml
 
@@ -107,12 +107,12 @@ echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] \
 https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /" \
 | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-apt-get update
+apt update
 ```
 
 9. Instalar kubeadm, kubelet y kubectl:
 ```bash
-apt-get install -y kubeadm=1.30.1-1.1 kubelet=1.30.1-1.1 kubectl=1.30.1-1.1
+apt install -y kubeadm=1.30.1-1.1 kubelet=1.30.1-1.1 kubectl=1.30.1-1.1
 
 apt-mark hold kubelet kubeadm kubectl # Bloquear actualizaciones automáticas
 ```
@@ -140,7 +140,7 @@ sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
 
 sudo chown $(id -u):$(id -g) $HOME/.kube/config
 
-sudo apt-get install bash-completion -y
+sudo apt install bash-completion -y
 
 source <(kubectl completion bash)
 

--- a/docs/cursos/kubernetes/103.Instalacion.md
+++ b/docs/cursos/kubernetes/103.Instalacion.md
@@ -152,13 +152,13 @@ Esto nos permitirá usar autocompletado en la terminal de bash y si tabulamos de
 
 13. Instalar Helm, necesario para instalar algunas aplicaciones en Kubernetes, incluido cilium (la CNI que vamos a instalar):
 ```bash
-curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
+curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
 
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+echo "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
 
-sudo apt-get update
+sudo apt update
 
-sudo apt-get install helm -y
+sudo apt install helm -y
 ```
 
 14. Instalar cilium, una CNI que nos permitirá conectar los pods entre sí:


### PR DESCRIPTION
Instrucciones de instalación de Helm obtenidas de: <https://helm.sh/docs/intro/install/#from-apt-debianubuntu>

También se han sustituido los comandos apt-get por apt.