### PR TITLE
chore: update npm dependencies to latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,23 +9,23 @@
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "^3.9.2",
-        "@docusaurus/preset-classic": "^3.9.0",
-        "@docusaurus/theme-mermaid": "^3.9.0",
-        "@mdx-js/react": "^3.1.0",
+        "@docusaurus/preset-classic": "^3.9.2",
+        "@docusaurus/theme-mermaid": "^3.9.2",
+        "@mdx-js/react": "^3.1.1",
         "clsx": "^2.1.1",
         "d3": "^7.9.0",
-        "docusaurus-lunr-search": "^3.6.0",
-        "dotenv": "^17.3.0",
+        "docusaurus-lunr-search": "^3.6.1",
+        "dotenv": "^17.3.1",
         "gray-matter": "^4.0.3",
-        "prism-react-renderer": "^2.3.0",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.1",
+        "prism-react-renderer": "^2.4.1",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
         "react-force-graph-2d": "^1.29.1",
         "react-github-btn": "^1.4.0"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "^3.7.0",
-        "@docusaurus/types": "^3.7.0"
+        "@docusaurus/module-type-aliases": "^3.9.2",
+        "@docusaurus/types": "^3.9.2"
       },
       "engines": {
         "node": ">=20.0"
@@ -9008,9 +9008,9 @@
       }
     },
     "node_modules/docusaurus-lunr-search": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/docusaurus-lunr-search/-/docusaurus-lunr-search-3.6.0.tgz",
-      "integrity": "sha512-CCEAnj5e67sUZmIb2hOl4xb4nDN07fb0fvRDDmdWlYpUvyS1CSKbw4lsGInLyUFEEEBzxQmT6zaVQdF/8Zretg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/docusaurus-lunr-search/-/docusaurus-lunr-search-3.6.1.tgz",
+      "integrity": "sha512-ms2FWYzR7OrvS2x0/HSPaAenAATrBenGpCwWpjmpK8SnUpqygVPvuss2RG5l2ZuMxpKFP0rhEnEy8Kx4lSQimw==",
       "license": "MIT",
       "dependencies": {
         "autocomplete.js": "^0.37.1",
@@ -9241,9 +9241,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.0.tgz",
-      "integrity": "sha512-i3z5dx/8F45f+Dj0B/qG8oKip9luzyHz6dfJMOKG7zQW/12tT7CrIjs/0J10uNK/Z5O7O0UtfEmx6yFKRQCl4g==",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -17,23 +17,23 @@
   },
   "dependencies": {
     "@docusaurus/core": "^3.9.2",
-    "@docusaurus/preset-classic": "^3.9.0",
-    "@docusaurus/theme-mermaid": "^3.9.0",
-    "@mdx-js/react": "^3.1.0",
+    "@docusaurus/preset-classic": "^3.9.2",
+    "@docusaurus/theme-mermaid": "^3.9.2",
+    "@mdx-js/react": "^3.1.1",
     "clsx": "^2.1.1",
     "d3": "^7.9.0",
     "docusaurus-lunr-search": "^3.6.1",
-    "dotenv": "^17.0.0",
+    "dotenv": "^17.3.1",
     "gray-matter": "^4.0.3",
-    "prism-react-renderer": "^2.3.0",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.1",
-    "react-force-graph-2d": "^1.27.1",
+    "prism-react-renderer": "^2.4.1",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "react-force-graph-2d": "^1.29.1",
     "react-github-btn": "^1.4.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.7.0",
-    "@docusaurus/types": "^3.7.0"
+    "@docusaurus/module-type-aliases": "^3.9.2",
+    "@docusaurus/types": "^3.9.2"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Actualización de dependencias

Actualizadas las siguientes librerías npm a sus últimas versiones disponibles:

| Paquete | Antes | Después |
|---|---|---|
| `@docusaurus/core` | ^3.9.0 | ^3.9.2 |
| `@docusaurus/preset-classic` | ^3.9.0 | ^3.9.2 |
| `@docusaurus/theme-mermaid` | ^3.9.0 | ^3.9.2 |
| `@docusaurus/module-type-aliases` | ^3.7.0 | ^3.9.2 |
| `@docusaurus/types` | ^3.7.0 | ^3.9.2 |
| `@mdx-js/react` | ^3.1.0 | ^3.1.1 |
| `dotenv` | ^17.0.0 | ^17.3.1 |
| `prism-react-renderer` | ^2.3.0 | ^2.4.1 |
| `react` | ^19.1.0 | ^19.2.4 |
| `react-dom` | ^19.1.1 | ^19.2.4 |
| `react-force-graph-2d` | ^1.27.1 | ^1.29.1 |

✅ Build verificado localmente — sin errores nuevos.